### PR TITLE
Remove ethtool containers when done

### DIFF
--- a/cli/cmd/plugin/standalone-cluster/hack/patch-node-for-antrea.sh
+++ b/cli/cmd/plugin/standalone-cluster/hack/patch-node-for-antrea.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 peerIdx=$(docker exec $1 ip link | grep eth0 | awk -F[@:] '{ print $3 }' | cut -c 3-)
-peerName=$(docker run --net=host antrea/ethtool:latest ip link | grep ^"$peerIdx": | awk -F[:@] '{ print $2 }' | cut -c 2-)
-docker run --net=host --privileged antrea/ethtool:latest ethtool -K "$peerName" tx off
+peerName=$(docker run --rm --net=host antrea/ethtool:latest ip link | grep ^"$peerIdx": | awk -F[:@] '{ print $2 }' | cut -c 2-)
+docker run --rm --net=host --privileged antrea/ethtool:latest ethtool -K "$peerName" tx off
 docker exec "$1" sysctl -w net.ipv4.conf.all.route_localnet=1


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

During cluster deployment, the ethtool container is run a few times to
get network information. These containers are run by calling out to
docker run, then they are left behind after the output is received from
them.

This adds the `--rm` argument to the `docker run` command so these
containers go away after we are done with them.

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
NONE
```